### PR TITLE
解决vite运行时Could not resolve "./components/vue-ruler-tool"报错

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 /*
  Created by Gorky on 2018/9/15
 */
-export { default } from './components/vue-ruler-tool'
+export { default } from './components/vue-ruler-tool.vue'


### PR DESCRIPTION
报错信息
Could not resolve "./components/vue-ruler-tool"

    node_modules/vue-ruler-tool/src/index.js:4:24:
      4 │ export { default } from './components/vue-ruler-tool'